### PR TITLE
Invoke main dependencies in order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SRC = thinfat32.c fat32_ui.c tests.c
 OBJS = $(SRC:%.c=$(OBJ_DIR)/%.o)
 
 VPATH = $(SRC_DIR)
-all: begin tests end
+all: | begin tests end
 
 begin:
 	@echo 


### PR DESCRIPTION
To make sure the dependencies will be executed in order, the pipe '|' sign is required before the list start.
Important while executing in multi-process (-j) build.